### PR TITLE
Arreglos en tipo de impuesto IVA- RENTA y arreglo de autofactura

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facturacionelectronicapy-xmlgen",
-  "version": "1.0.189",
+  "version": "1.0.190",
   "description": "API Node JS para generar el archivo XML del Documento electrónico exigido por la SET en base a JSON",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facturacionelectronicapy-xmlgen",
-  "version": "1.0.188",
+  "version": "1.0.189",
   "description": "API Node JS para generar el archivo XML del Documento electrónico exigido por la SET en base a JSON",
   "main": "dist/index.js",
   "scripts": {

--- a/src/services/jsonDteIdentificacionDocumento.service.ts
+++ b/src/services/jsonDteIdentificacionDocumento.service.ts
@@ -90,8 +90,10 @@ class JSonDteIdentificacionDocumentoService {
         jsonResult['dDesTipCons'] = constanteService.tiposConstancias.filter(
           (tc) => tc.codigo === dataDocumentoAsociado['constanciaTipo'],
         )[0]['descripcion'];
-        jsonResult['dNumCons'] = +dataDocumentoAsociado['constanciaNumero'];
-        jsonResult['dNumControl'] = dataDocumentoAsociado['constanciaControl'];
+        if(dataDocumentoAsociado['constanciaTipo'] === 2) {
+          jsonResult['dNumCons'] = +dataDocumentoAsociado['constanciaNumero'];
+          jsonResult['dNumControl'] = dataDocumentoAsociado['constanciaControl'];
+        }
       }
     }
     return jsonResult;

--- a/src/services/jsonDteTotales.service.ts
+++ b/src/services/jsonDteTotales.service.ts
@@ -171,7 +171,7 @@ class JSonDteTotalesService {
         if (dSub5 > 0) {
           jsonResult['dSub5'] = dSub5;
           //if (data.moneda != 'PYG') { //Redondea el tax, independiente a la moneda
-          jsonResult['dSub5'] = parseFloat(dSub5.toFixed(config.taxDecimals));npm 
+          jsonResult['dSub5'] = parseFloat(dSub5.toFixed(config.taxDecimals));
           //}
 
           //if (data.moneda != 'PYG') { //Codigo duplicado

--- a/src/services/jsonDteTotales.service.ts
+++ b/src/services/jsonDteTotales.service.ts
@@ -52,8 +52,8 @@ class JSonDteTotalesService {
         }
         //Gravadas 5 o 10
         if (item['gCamIVA']['iAfecIVA'] == 1 || item['gCamIVA']['iAfecIVA'] == 4) {
-          if (!(data['tipoImpuesto'] != 1)) {
-            //No debe existir si D013 != 1
+          if (data['tipoImpuesto'] === 1 || data['tipoImpuesto'] === 5) {
+            //Debe existir si D013 = 1 o D013 = 5
             if (item['gCamIVA']['dTasaIVA'] == 5) {
               //E734
               dSub5 += item['gValorItem']['gValorRestaItem']['dTotOpeItem'];
@@ -166,12 +166,12 @@ class JSonDteTotalesService {
     };
 
     if (agregarDSub) {
-      if (!(data['tipoImpuesto'] != 1)) {
-        //No debe existir si D013 != 1        if (dSub5 > 0) {
+      if (data['tipoImpuesto'] === 1 || data['tipoImpuesto'] === 5) {
+        //debe existir si D013 = 1 o D013 = 5
         if (dSub5 > 0) {
           jsonResult['dSub5'] = dSub5;
           //if (data.moneda != 'PYG') { //Redondea el tax, independiente a la moneda
-          jsonResult['dSub5'] = parseFloat(dSub5.toFixed(config.taxDecimals));
+          jsonResult['dSub5'] = parseFloat(dSub5.toFixed(config.taxDecimals));npm 
           //}
 
           //if (data.moneda != 'PYG') { //Codigo duplicado


### PR DESCRIPTION
Estuvimos en conversaciones con la set y hay un error en el manual, van a sacar una nueva nota tecnica corrigiendo este tema. En tipo de impuesto IVA - RENTA si hay que reportar esos campos.
![image](https://user-images.githubusercontent.com/10813272/225694140-41750140-d32a-4959-ae62-81056d6f4efd.png)

El arreglo ya estaria de esa futura nota tecnica.

El otro arreglo es un control que dice esto segun el manual 
![image](https://user-images.githubusercontent.com/10813272/225690409-310fcfd5-7f40-4766-a9f7-b9256b1447f7.png)

Descripcion
Se arreglo tema de tipo de impuesto IVA - RENTA(5) para que genere los campos de dsub5 y dsub10, tambien los campos de iva en los subtotales(dIva5 y dIva10), tambien se hizo un arreglo de que el numero de constancia y control solo se generen cuando el tipo de constancia = 2 como dice el manual