### PR TITLE
Corrección datos constants.service.ts

### DIFF
--- a/src/services/constants.service.ts
+++ b/src/services/constants.service.ts
@@ -198,11 +198,11 @@ class ConstanteService {
     },
     {
       codigo: 211,
-      descripcion: 'IMPUESTO AL VALOR AGREGADO - GRAVADAS Y EXONERADAS – EXPORTADORES',
+      descripcion: 'IMPUESTO AL VALOR AGREGADO - GRAVADAS Y EXONERADAS - EXPORTADORES',
     },
     {
       codigo: 311,
-      descripcion: 'IMPUESTO SELECTIVO AL CONSUMO – GENERAL',
+      descripcion: 'IMPUESTO SELECTIVO AL CONSUMO - GENERAL',
     },
     {
       codigo: 321,
@@ -214,7 +214,7 @@ class ConstanteService {
     },
     {
       codigo: 701,
-      descripcion: 'IMPUESTO A LA RENTA EMPRESARIAL – SIMPLE',
+      descripcion: 'IMPUESTO A LA RENTA EMPRESARIAL - SIMPLE',
     },
     {
       codigo: 703,
@@ -222,7 +222,7 @@ class ConstanteService {
     },
     {
       codigo: 702,
-      descripcion: 'IMPUESTO A LA RENTA EMPRESARIAL – RESIMPLE',
+      descripcion: 'IMPUESTO A LA RENTA EMPRESARIAL - RESIMPLE',
     },
     {
       codigo: 715,


### PR DESCRIPTION
En la lista de elementos que corresponden a las obligaciones, las descripciones tenían `–` el cual la SIFEN rechaza, se reemplazan por `-` (guión normal)

> La prueba de esta corrección fue probada únicamente en el entorno de **TEST** y los documentos fueron aceptados