### PR TITLE
Update jsonDeMain.service.ts | Se corrige Error  Cannot read properties of null (reading 'numero_casa') cuando se envía data.autofactura = null

### DIFF
--- a/src/services/jsonDeMain.service.ts
+++ b/src/services/jsonDeMain.service.ts
@@ -351,12 +351,11 @@ class JSonDeMainService {
     if (data.autoFactura?.documento_numero) {
       data.autoFactura.documentoNumero = data.autoFactura.documento_numero;
     }
-
-    if (typeof data.autoFactura != 'undefined' && typeof data.autoFactura.numero_casa != 'undefined') {
-      if (data.autoFactura.numero_casa != null) {
-        data.autoFactura.numeroCasa = data.autoFactura.numero_casa + '';
-      }
-    }
+	    if (data.autoFactura != null && typeof data.autoFactura != 'undefined' && typeof data.autoFactura.numero_casa != 'undefined') {
+            if (data.autoFactura.numero_casa != null) {
+                data.autoFactura.numeroCasa = data.autoFactura.numero_casa + '';
+            }
+        }
 
     /*if (data.autoFactura?.numero_casa) {
       data.autoFactura.numeroCasa = data.autoFactura.numero_casa;


### PR DESCRIPTION
Corrige la validación de `data.autoFactura` para evitar errores cuando es `null`

Se ha ajustado la validación para comprobar si `data.autoFactura` es `null` antes de verificar sus propiedades. La validación anterior no manejaba correctamente el caso en que `data.autoFactura` fuera `null`, lo que resultaba en un error al intentar leer `numero_casa` de un objeto `null`.

- Se cambió la validación a:  javascript `if (data.autoFactura != null && typeof data.autoFactura !== 'undefined' && typeof data.autoFactura.numero_casa !== 'undefined') { if (data.autoFactura.numero_casa != null) { data.autoFactura.numeroCasa = data.autoFactura.numero_casa + ''; } }`